### PR TITLE
regexps for images - add webp and remove $

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -22,7 +22,7 @@ var extRegexps = {
   maybe: /and|article|body|column|main|column/i,
   div2p: /<(a|blockquote|dl|div|img|ol|p|pre|table|ul|span|font|label)/i,
   uselessAnchors: /(\d+|next|prev|first|last|print|comment|mail|font|about|contact|(下|下|前|后)一|(首|尾)页)|打印|评论|邮件|信箱|转发|关于|联系|^(大|中|小)$/i,
-  images: /\.(gif|jpe?g|png)$/i
+  images: /\.(gif|jpe?g|png|webp)/i
 }
 var tagsToSkip = ''
 var tagsOfMedia = ''


### PR DESCRIPTION
It is necessary to have $ at the end of reqex (I do not understand reqex to much)? Images with src like "/images/for.png?1716226" (some kind of cache busting) are not recognized now. 
Also I suggest add webp because is quite popular nowadays.
